### PR TITLE
Newman output, htmlextra prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To run one or more conformance test suites:
 * Install OpenJDK 17: https://openjdk.org/projects/jdk/17/
 * Install Maven 3: https://maven.apache.org/download.cgi
 * Install newman: https://github.com/postmanlabs/newman#installation
+* Install newman-reporter-htmlextra: https://www.npmjs.com/package/newman-reporter-htmlextra#install
 
 ### Starting the API provider
 To run conformance tests against the DCSA reference implementation of a supported standard, start the reference implementation as API provider using its own documentation:


### PR DESCRIPTION
I didn't have htmlextra installed so newman failed as subprocess, but its output was not relayed so it was not clear why. Both the stdout and the stderr of a child process must be consumed anyway, even if not used, to prevent the child process from hanging when one of its output buffers is full.